### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: feathers-app
+  annotations:
+    github.com/project-slug: tsfrt/feathers-app
+spec:
+  type: other
+  lifecycle: unknown
+  owner: default-org


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [VMware Tanzu Application Platform software catalog](https://tap-gui.tap.build.h2o-2-18171.h2o.vmware.com).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).